### PR TITLE
Delay DBus registration until CAN activity and monitor connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ All information, files, suggestions are to be used at your own risk, I offer zer
   a persistent service under `/opt/victronenergy/service/`.
 * The service now starts via the Utilities service manager rather than `inittab`.
 * I did a factory reinstall with the latest venus image just to be sure that it is starting fresh again. Guide: [Factory Reinstall](https://www.victronenergy.com/media/pg/Cerbo_GX/en/reset-to-factory-defaults-and-venus-os-reinstall.html)
+* The service only registers on D-Bus after receiving CAN messages and toggles the `/Connected` path if communication is lost.
 
 
 # Background

--- a/dbus-canbus-battery.py
+++ b/dbus-canbus-battery.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 import threading
 import time
+import select
 from vedbus import VeDbusService
 from gi.repository import GLib
 import platform
@@ -52,7 +53,7 @@ class DbusBatteryService:
         self._dbusservice.add_path('/ProductName', 'ELPM482-00005')
         self._dbusservice.add_path('/FirmwareVersion', 0)
         self._dbusservice.add_path('/HardwareVersion', 0)
-        self._dbusservice.add_path('/Connected', 1)
+        self._dbusservice.add_path('/Connected', 0)
 
         # Paths
         self._dbusservice.add_path('/Info/MaxDischargeCurrent', 0.0)
@@ -78,7 +79,10 @@ class DbusBatteryService:
         for alarm in ['HighVoltage', 'LowVoltage', 'HighTemperature', 'LowTemperature', 'HighChargeCurrent', 'HighDischargeCurrent', 'HighChargeTemperature', 'CellImbalance']:
             self._dbusservice.add_path(f'/Alarms/{alarm}', 0)
 
-        self._dbusservice.register()
+        self.service_registered = False
+        self.connected = False
+        self.last_message_time = None
+        self.connection_timeout = 5
 
         self.data_buffer = {path: [] for can_id in CAN_MAPPINGS for path in CAN_MAPPINGS[can_id]}
         self.precision_buffer = {path: CAN_MAPPINGS[can_id][path].get("precision") for can_id in CAN_MAPPINGS for path in CAN_MAPPINGS[can_id]}
@@ -89,6 +93,12 @@ class DbusBatteryService:
 
         threading.Thread(target=self._start_dbus_update_loop).start()
         self._can_listener()
+
+    def _register_dbus_service(self):
+        if not self.service_registered:
+            self._dbusservice.register()
+            self.service_registered = True
+            logging.info("D-Bus service registered")
 
     def _start_dbus_update_loop(self):
         """Run the GLib main loop that publishes buffered data to D-Bus."""
@@ -111,20 +121,34 @@ class DbusBatteryService:
         logging.info("Started processing CAN output...")
         try:
             while True:
-                output = self.proc.stdout.readline()
-                if output == '' and self.proc.poll() is not None:
-                    break
-                if output:
-                    logging.debug(f"candump output: {output.strip()}")
-                    parts = output.split()
-                    can_id = parts[1]
-                    data = parts[3:]
-                    if data[0] == '[8]':
-                        data = data[1:]
-                    logging.debug(f"Parsed CAN ID: {can_id}, Data: {data}")
-                    if can_id in CAN_MAPPINGS:
-                        self._parse_can_data(can_id, data)
-                   
+                rlist, _, _ = select.select([self.proc.stdout], [], [], 1)
+                if rlist:
+                    output = self.proc.stdout.readline()
+                    if output == '' and self.proc.poll() is not None:
+                        break
+                    if output:
+                        self.last_message_time = time.time()
+                        if not self.service_registered:
+                            self._register_dbus_service()
+                        if not self.connected:
+                            self.connected = True
+                            self._dbusservice['/Connected'] = 1
+                        logging.debug(f"candump output: {output.strip()}")
+                        parts = output.split()
+                        can_id = parts[1]
+                        data = parts[3:]
+                        if data[0] == '[8]':
+                            data = data[1:]
+                        logging.debug(f"Parsed CAN ID: {can_id}, Data: {data}")
+                        if can_id in CAN_MAPPINGS:
+                            self._parse_can_data(can_id, data)
+                else:
+                    if self.proc.poll() is not None:
+                        break
+                    if self.connected and self.last_message_time and time.time() - self.last_message_time > self.connection_timeout:
+                        logging.warning("Connection to battery lost")
+                        self.connected = False
+                        self._dbusservice['/Connected'] = 0
 
                 if time.time() - self.start_time >= 10:
                     self._send_averaged_data()


### PR DESCRIPTION
## Summary
- Register D-Bus service only after the first CAN frame is received and initialize `/Connected` to 0
- Track last CAN message and drop `/Connected` to 0 if the bus is quiet, restoring it on activity
- Document the new connection logic in the README

## Testing
- `python -m py_compile dbus-canbus-battery.py vedbus.py ve_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6896bcf0bde8832288b5947518a5720d