### PR TITLE
Use daemontools logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ First troubleshooting step is to run the `ps | grep dbus-canbus` command as befo
 **If the service is running:**
 - Check the log files by running the command
 ```bash
-cat /var/log/dbus-canbus-battery/current
+tail -F /var/log/dbus-canbus-battery/current | tai64nlocal
 ```
 - check for last entries.
+
+- For more verbose logging, restart the service with `LOG_LEVEL=DEBUG` set so
+  debug messages are written to the log.
 
 **If the service is not running**
 You may run into some issues if I've forgotten any dependencies since I started this little project.
@@ -101,7 +104,7 @@ python3 /data/dbus-canbus-battery/dbus-canbus-battery.py
 ```
 - View Logs
 ```bash
-tail -f /var/log/dbus-canbus-battery.log
+tail -F /var/log/dbus-canbus-battery/current | tai64nlocal
 ```
 
 # Proof it works :p

--- a/dbus-canbus-battery.py
+++ b/dbus-canbus-battery.py
@@ -3,6 +3,7 @@
 import os
 import json
 import logging
+import sys
 import subprocess
 import threading
 import time
@@ -11,12 +12,12 @@ from gi.repository import GLib
 import platform
 from dbus.mainloop.glib import DBusGMainLoop
 
-# Configure logging to write to a file with timestamps
+# Configure logging to output to stdout so daemontools can capture it
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
-    level=logging.WARNING,
+    level=getattr(logging, log_level, logging.INFO),
     format='%(asctime)s %(levelname)s: %(message)s',
-    filename='/var/log/dbus-canbus-battery.log',
-    filemode='a'
+    stream=sys.stdout
 )
 
 # Set the PYTHONPATH programmatically to ensure 'vedbus' can be found

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,9 @@ rm -f "$ZIP_NAME"
 mv "$TMP_DIR" "$FINAL_DIR"
 cd "$FINAL_DIR"
 
+# Ensure log directory exists for multilog
+mkdir -p /var/log/dbus-canbus-battery
+
 # Ensure Python and run scripts are executable
 find . -name "*.py" -type f -exec chmod +x {} +
 find service -name run -type f -exec chmod +x {} +

--- a/service/run
+++ b/service/run
@@ -1,4 +1,3 @@
 #!/bin/sh
-echo "*** starting dbus-canbus-battery ***"
 exec 2>&1
-exec /data/dbus-canbus-battery/dbus-canbus-battery.py >> /var/log/dbus-canbus-battery.log 2>&1
+exec /data/dbus-canbus-battery/dbus-canbus-battery.py


### PR DESCRIPTION
## Summary
- Send Python log output to stdout so daemontools handles rotation
- Simplify service scripts and installer for multilog
- Document new log viewing commands
- Allow the log level to be overridden with the LOG_LEVEL environment variable

## Testing
- `python -m py_compile dbus-canbus-battery.py`


------
https://chatgpt.com/codex/tasks/task_e_6896e2a38aac8322b558c4cff5c1cf72