### PR TITLE
Add connection monitoring, resilient CAN mapping, and auto-restart

### DIFF
--- a/dbus-canbus-battery.py
+++ b/dbus-canbus-battery.py
@@ -33,6 +33,9 @@ CAN_MAPPING_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(CAN_MAPPING_PATH) as f:
     CAN_MAPPINGS = json.load(f)
     logging.debug(f"Loaded CAN_MAPPINGS: {json.dumps(CAN_MAPPINGS, indent=2)}")
+
+# Time in seconds before the battery is considered disconnected
+CONNECTION_TIMEOUT = 5
     
 class DbusBatteryService:
     def __init__(self):
@@ -50,7 +53,8 @@ class DbusBatteryService:
         self._dbusservice.add_path('/ProductName', 'ELPM482-00005')
         self._dbusservice.add_path('/FirmwareVersion', 0)
         self._dbusservice.add_path('/HardwareVersion', 0)
-        self._dbusservice.add_path('/Connected', 1)
+        # Start disconnected until CAN frames are received
+        self._dbusservice.add_path('/Connected', 0)
 
         # Paths
         self._dbusservice.add_path('/Info/MaxDischargeCurrent', 0.0)
@@ -84,6 +88,8 @@ class DbusBatteryService:
 
         self.installed_capacity = 0
         self.soc = 0
+        self.last_valid_can_time = None
+        self.last_dbus_update_time = time.time()
 
         threading.Thread(target=self._start_dbus_update_loop).start()
         self._can_listener()
@@ -96,7 +102,8 @@ class DbusBatteryService:
 
     def _can_listener(self):
         logging.info("Starting CAN listener...")
-        self.proc = subprocess.Popen(['candump', 'can1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        # Listen on any available CAN interface instead of a fixed one
+        self.proc = subprocess.Popen(['candump', 'any'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         self._process_can_output()
 
     def _process_can_output(self):
@@ -109,13 +116,17 @@ class DbusBatteryService:
                 if output:
                     logging.debug(f"candump output: {output.strip()}")
                     parts = output.split()
+                    if len(parts) < 4:
+                        logging.debug("Malformed CAN line received, skipping")
+                        continue
                     can_id = parts[1]
                     data = parts[3:]
-                    if data[0] == '[8]':
+                    if data and data[0].startswith('['):
                         data = data[1:]
                     logging.debug(f"Parsed CAN ID: {can_id}, Data: {data}")
                     if can_id in CAN_MAPPINGS:
                         self._parse_can_data(can_id, data)
+                        self.last_valid_can_time = time.time()
                     else:
                         logging.debug(f"CAN ID: {can_id} not present")
 
@@ -128,13 +139,18 @@ class DbusBatteryService:
             self.proc.terminate()
 
     def _parse_can_data(self, can_id, data):
-        mapping = CAN_MAPPINGS[can_id]
+        mapping = CAN_MAPPINGS.get(can_id, {})
         for path, config in mapping.items():
             try:
+                bytes_list = config.get("bytes")
+                data_type = config.get("type")
+                if bytes_list is None or data_type is None:
+                    logging.error(f"Invalid mapping for {can_id} -> {path}, skipping")
+                    continue
                 value = self._extract_value(
                     data,
-                    config["bytes"],
-                    config["type"],
+                    bytes_list,
+                    data_type,
                     config.get("scale", 1),
                     config.get("byte_order"),
                     bit=config.get("bit"),
@@ -143,15 +159,25 @@ class DbusBatteryService:
                 )
                 logging.debug(f"Parsed {path} from {can_id}: {value}")
                 if value is not None:
-                    self.data_buffer[path].append(value)
+                    self.data_buffer.setdefault(path, []).append(value)
+                    if path not in self.precision_buffer:
+                        self.precision_buffer[path] = config.get("precision")
             except Exception as e:
                 logging.error(f"Error parsing {path} from CAN ID {can_id}: {e}")
 
     def _extract_value(self, data, bytes_list, data_type, scale, byte_order=None, bit=None, true_value=2, false_value=0):
-        raw_bytes = [data[i] for i in bytes_list]
+        try:
+            raw_bytes = [data[i] for i in bytes_list]
+        except IndexError:
+            logging.error(f"Data {data} too short for bytes {bytes_list}")
+            return None
         if byte_order == "reversed":
             raw_bytes.reverse()
-        raw_value = int(''.join(raw_bytes), 16)
+        try:
+            raw_value = int(''.join(raw_bytes), 16)
+        except ValueError as e:
+            logging.error(f"Invalid hex data {raw_bytes}: {e}")
+            return None
         if data_type == "bool" and bit is not None:
             is_bit_set = (raw_value >> bit) & 1
             return true_value if is_bit_set else false_value
@@ -175,6 +201,7 @@ class DbusBatteryService:
         nr_of_modules_online = None
         voltage = None
         current = None
+        updated = False
         for path, values in self.data_buffer.items():
             if values:
                 avg_value = self._average(values)
@@ -183,6 +210,7 @@ class DbusBatteryService:
                     avg_value = float(f"{avg_value:.{precision}f}")
                 logging.info(f"Setting averaged {path}: {avg_value}")
                 self._dbusservice[path] = avg_value
+                updated = True
                 logging.debug(f"D-Bus write: {path} = {avg_value}")
                 if path == '/Dc/0/Voltage':
                     voltage = avg_value
@@ -196,15 +224,36 @@ class DbusBatteryService:
             power = round(voltage * current)
             logging.info(f"Setting /Dc/0/Power: {power}")
             self._dbusservice['/Dc/0/Power'] = power
+            updated = True
         if nr_of_modules_online is not None:
             self.installed_capacity = nr_of_modules_online * 94
             logging.info(f"Setting /InstalledCapacity: {self.installed_capacity}")
             self._dbusservice['/InstalledCapacity'] = self.installed_capacity
+            updated = True
         if self.installed_capacity and self.soc:
             self._calculate_available_capacity()
+            updated = True
+        if updated:
+            self.last_dbus_update_time = time.time()
 
     def _update(self):
         logging.debug("Updating D-Bus battery data...")
+        now = time.time()
+        if self.last_valid_can_time and now - self.last_valid_can_time <= CONNECTION_TIMEOUT:
+            if self._dbusservice['/Connected'] != 1:
+                logging.info("CAN connection established")
+                self._dbusservice['/Connected'] = 1
+        else:
+            if self._dbusservice['/Connected'] != 0:
+                logging.warning("CAN connection lost")
+                self._dbusservice['/Connected'] = 0
+        if now - self.last_dbus_update_time > 60:
+            logging.error("No D-Bus updates for 60 seconds. Restarting service.")
+            try:
+                if hasattr(self, 'proc') and self.proc.poll() is None:
+                    self.proc.terminate()
+            finally:
+                os._exit(1)
         return True
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Track last valid CAN frame and update `/Connected` based on activity
- Listen on any CAN interface and handle malformed data safely
- Harden CAN mapping parsing to avoid crashes on bad definitions
- Restart service via daemontools if no D-Bus updates for 60 seconds

## Testing
- `python -m py_compile dbus-canbus-battery.py`


------
https://chatgpt.com/codex/tasks/task_e_6896f1a07f848322be476284790778bc