### PR TITLE
Testing new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ From this point forward I will refer to the Venus OS device as Cerbo GX and inst
 2) Enable root account and SSH: [Root Access](https://www.victronenergy.com/live/ccgx:root_access)
 3) SSH to the Cerbo GX and run the install script:
 ```bash
-wget https://raw.githubusercontent.com/Spidy01/dbus-canbus-battery/main/install.sh -O install.sh
+wget https://raw.githubusercontent.com/o-snoopy-o/dbus-canbus-battery/main/install.sh -O install.sh
 sh install.sh
 ```
 4) Reboot the device once the script completes.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Ensure that you have the CANBUS cable connected to the BMS and the Cerbo GX. The
 3) Open an SSH session to your Cerbo GX.
 4) Download and execute the installer which will place the code under `/data` and register the service:
 ```bash
-wget https://raw.githubusercontent.com/Spidy01/dbus-canbus-battery/main/install.sh -O install.sh
+wget https://raw.githubusercontent.com/o-snoopy-o/dbus-canbus-battery/main/install.sh -O install.sh
 sh install.sh
 ```
 5) Reboot the device:

--- a/dbus-canbus-battery.py
+++ b/dbus-canbus-battery.py
@@ -33,6 +33,9 @@ CAN_MAPPING_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(CAN_MAPPING_PATH) as f:
     CAN_MAPPINGS = json.load(f)
     logging.debug(f"Loaded CAN_MAPPINGS: {json.dumps(CAN_MAPPINGS, indent=2)}")
+
+# Time in seconds before the battery is considered disconnected
+CONNECTION_TIMEOUT = 5
     
 class DbusBatteryService:
     def __init__(self):
@@ -50,7 +53,8 @@ class DbusBatteryService:
         self._dbusservice.add_path('/ProductName', 'ELPM482-00005')
         self._dbusservice.add_path('/FirmwareVersion', 0)
         self._dbusservice.add_path('/HardwareVersion', 0)
-        self._dbusservice.add_path('/Connected', 1)
+        # Start disconnected until CAN frames are received
+        self._dbusservice.add_path('/Connected', 0)
 
         # Paths
         self._dbusservice.add_path('/Info/MaxDischargeCurrent', 0.0)
@@ -84,6 +88,8 @@ class DbusBatteryService:
 
         self.installed_capacity = 0
         self.soc = 0
+        self.last_valid_can_time = None
+        self.last_dbus_update_time = time.time()
 
         threading.Thread(target=self._start_dbus_update_loop).start()
         self._can_listener()
@@ -96,7 +102,8 @@ class DbusBatteryService:
 
     def _can_listener(self):
         logging.info("Starting CAN listener...")
-        self.proc = subprocess.Popen(['candump', 'can1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        # Listen on any available CAN interface instead of a fixed one
+        self.proc = subprocess.Popen(['candump', 'any'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         self._process_can_output()
 
     def _process_can_output(self):
@@ -109,13 +116,17 @@ class DbusBatteryService:
                 if output:
                     logging.debug(f"candump output: {output.strip()}")
                     parts = output.split()
+                    if len(parts) < 4:
+                        logging.debug("Malformed CAN line received, skipping")
+                        continue
                     can_id = parts[1]
                     data = parts[3:]
-                    if data[0] == '[8]':
+                    if data and data[0].startswith('['):
                         data = data[1:]
                     logging.debug(f"Parsed CAN ID: {can_id}, Data: {data}")
                     if can_id in CAN_MAPPINGS:
                         self._parse_can_data(can_id, data)
+                        self.last_valid_can_time = time.time()
                     else:
                         logging.debug(f"CAN ID: {can_id} not present")
 
@@ -128,13 +139,18 @@ class DbusBatteryService:
             self.proc.terminate()
 
     def _parse_can_data(self, can_id, data):
-        mapping = CAN_MAPPINGS[can_id]
+        mapping = CAN_MAPPINGS.get(can_id, {})
         for path, config in mapping.items():
             try:
+                bytes_list = config.get("bytes")
+                data_type = config.get("type")
+                if bytes_list is None or data_type is None:
+                    logging.error(f"Invalid mapping for {can_id} -> {path}, skipping")
+                    continue
                 value = self._extract_value(
                     data,
-                    config["bytes"],
-                    config["type"],
+                    bytes_list,
+                    data_type,
                     config.get("scale", 1),
                     config.get("byte_order"),
                     bit=config.get("bit"),
@@ -143,15 +159,25 @@ class DbusBatteryService:
                 )
                 logging.debug(f"Parsed {path} from {can_id}: {value}")
                 if value is not None:
-                    self.data_buffer[path].append(value)
+                    self.data_buffer.setdefault(path, []).append(value)
+                    if path not in self.precision_buffer:
+                        self.precision_buffer[path] = config.get("precision")
             except Exception as e:
                 logging.error(f"Error parsing {path} from CAN ID {can_id}: {e}")
 
     def _extract_value(self, data, bytes_list, data_type, scale, byte_order=None, bit=None, true_value=2, false_value=0):
-        raw_bytes = [data[i] for i in bytes_list]
+        try:
+            raw_bytes = [data[i] for i in bytes_list]
+        except IndexError:
+            logging.error(f"Data {data} too short for bytes {bytes_list}")
+            return None
         if byte_order == "reversed":
             raw_bytes.reverse()
-        raw_value = int(''.join(raw_bytes), 16)
+        try:
+            raw_value = int(''.join(raw_bytes), 16)
+        except ValueError as e:
+            logging.error(f"Invalid hex data {raw_bytes}: {e}")
+            return None
         if data_type == "bool" and bit is not None:
             is_bit_set = (raw_value >> bit) & 1
             return true_value if is_bit_set else false_value
@@ -175,6 +201,7 @@ class DbusBatteryService:
         nr_of_modules_online = None
         voltage = None
         current = None
+        updated = False
         for path, values in self.data_buffer.items():
             if values:
                 avg_value = self._average(values)
@@ -183,6 +210,7 @@ class DbusBatteryService:
                     avg_value = float(f"{avg_value:.{precision}f}")
                 logging.info(f"Setting averaged {path}: {avg_value}")
                 self._dbusservice[path] = avg_value
+                updated = True
                 logging.debug(f"D-Bus write: {path} = {avg_value}")
                 if path == '/Dc/0/Voltage':
                     voltage = avg_value
@@ -196,15 +224,36 @@ class DbusBatteryService:
             power = round(voltage * current)
             logging.info(f"Setting /Dc/0/Power: {power}")
             self._dbusservice['/Dc/0/Power'] = power
+            updated = True
         if nr_of_modules_online is not None:
             self.installed_capacity = nr_of_modules_online * 94
             logging.info(f"Setting /InstalledCapacity: {self.installed_capacity}")
             self._dbusservice['/InstalledCapacity'] = self.installed_capacity
+            updated = True
         if self.installed_capacity and self.soc:
             self._calculate_available_capacity()
+            updated = True
+        if updated:
+            self.last_dbus_update_time = time.time()
 
     def _update(self):
         logging.debug("Updating D-Bus battery data...")
+        now = time.time()
+        if self.last_valid_can_time and now - self.last_valid_can_time <= CONNECTION_TIMEOUT:
+            if self._dbusservice['/Connected'] != 1:
+                logging.info("CAN connection established")
+                self._dbusservice['/Connected'] = 1
+        else:
+            if self._dbusservice['/Connected'] != 0:
+                logging.warning("CAN connection lost")
+                self._dbusservice['/Connected'] = 0
+        if now - self.last_dbus_update_time > 60:
+            logging.error("No D-Bus updates for 60 seconds. Restarting service.")
+            try:
+                if hasattr(self, 'proc') and self.proc.poll() is None:
+                    self.proc.terminate()
+            finally:
+                os._exit(1)
         return True
 
 if __name__ == "__main__":

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Define paths
 INSTALL_DIR="/data"
-REPO_AUTHOR="Spidy01"
+REPO_AUTHOR="o-snoopy-o"
 REPO_NAME="dbus-canbus-battery"
 ZIP_NAME="repo.zip"
 TMP_DIR="${INSTALL_DIR}/${REPO_NAME}-main"


### PR DESCRIPTION
PR Comment
Introduces a deployable service that reads CAN frames, publishes battery metrics over D-Bus, and logs to stdout so daemontools can supervise it, improving reliability and observability.

Bundles an installer script that fetches the latest code, sets up symlinks, and restarts the service automatically, cutting setup time and minimizing manual steps.

Utilizes a JSON‑based CAN‑ID mapping and periodic averaging to deliver accurate SOC, voltage, and alarm data, giving users real‑time insights into battery health and capacity.

These changes streamline installation, offer clearer diagnostics when issues arise, and supply more precise battery information—ultimately making the system easier and more transparent for end users.

Potential Issues & Improvements
The service can only listen on “any” CAN interface, which might capture unwanted traffic when multiple CAN buses are present.

Suggested task
Allow configurable CAN interface

Start task
The JSON mapping file duplicates CAN IDs in two formats (e.g., "100" and "00000500"), which increases maintenance effort and risk of inconsistent mappings.

Suggested task
Normalize CAN ID formats in can-mappings.json

Start task
Loading can-mappings.json or launching candump can raise unhandled exceptions, causing the service to exit without a clear message.

Suggested task
Add robust error handling for startup failures

Start task
The parsing logic for CAN frames (_extract_value, _parse_can_data) lacks automated tests, making regressions hard to detect.

Suggested task
Introduce unit tests for CAN parsing

Start task
Functions throughout dbus-canbus-battery.py are undocumented, which can slow onboarding for new contributors.

Suggested task
Document service functions with docstrings and type hints

Start task